### PR TITLE
State command & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ Required Arguments:
   service_id   The ID of the service to perform the command on.
 ```
 
+### Get service's state
+
+```
+Usage: ./gaucho state <service_id>
+
+Print state of the given *service id*.
+
+Required Arguments:
+
+  service_id   The ID of the service to check.
+```
+
+
 ## Dependencies
 
  - requests

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Activate the given *service id*.
 Required Arguments:
 
   service_id   The ID of the service to perform the command on.
+
+Options:
+
+   --timeout            How many seconds to wait until get back prompt on activation
 ```
 
 ### deactivate command
@@ -172,6 +176,10 @@ Deactivate the given *service id*.
 Required Arguments:
 
   service_id   The ID of the service to perform the command on.
+
+Options:
+
+   --timeout            How many seconds to wait until get back prompt on deactivation
 ```
 
 ### Get service's state

--- a/services.py
+++ b/services.py
@@ -309,6 +309,19 @@ def deactivate (service_id):
    post(current_service_config['actions']['deactivate'], "");
 
 
+
+#
+# Get a service state
+#
+@baker.command(default=True, params={"service_id": "The ID of the service to read"})
+def state(service_id=""):
+   """Retrieves the service state information.
+   """
+
+   r = get(HOST + URL_SERVICE + service_id)
+   print(r.json()["state"])
+
+
 #
 # Script's entry point, starts Baker to execute the commands.
 # Attempts to read environment variables to configure the program.


### PR DESCRIPTION
Hi @etlweather ,

I've made new modifications:

1. Add some tests to not run `deactivation` on inactive service and, most important for me, wait for the end of deactivation before give back the prompt. Inspired from your `upgrade` command.
This is to avoid `sleep` commands in a script.

2. I've added a command to have the current state of a service. I thought a lot to use your `query` command and `grep`or `awk` but I would keep my scripts simple so I added this.

Hope you could find those usefull.

Thanks again for you work on this script, I'm using it all days on my CI workflows!

Regards
